### PR TITLE
🚑 fix: resolve "No Document Associated" despite document presence

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,6 +20,7 @@ export default defineNuxtConfig({
       sheet: {
         id: '',
         range: '',
+        freelancerKey: 'freelancer',
       },
       form: {
         id: '',

--- a/server/utils/documents.ts
+++ b/server/utils/documents.ts
@@ -89,8 +89,9 @@ export const getDataColumns = defineCachedFunction<DocumentTableColumn[]>(async 
 
 // Get raw data for a specific name (e.g., freelancer)
 export const getRawDataByName = defineCachedFunction<SheetValues>(async (event: H3Event, name: string) => {
+  const { freelancerKey } = useRuntimeConfig().google.sheet;
   const { headers, values } = await getSpreadsheetData(event);
-  const freelancerIndex = headers.findIndex(header => header.trim().toLowerCase() == 'freelancer');
+  const freelancerIndex = headers.findIndex(header => header.trim().toLowerCase() == freelancerKey);
   return {
     headers,
     values: freelancerIndex === -1


### PR DESCRIPTION
### **Root Cause:**
The issue was caused by a change in the column name from `freelancer` to `inti`, which was not reflected in the code. This mismatch caused the system to fail in finding the associated document.

![image](https://github.com/user-attachments/assets/64486c5d-accb-488d-921a-eaf2e45a0d51)

![image](https://github.com/user-attachments/assets/467356a0-df34-4981-a9a4-a03661320cb2)
